### PR TITLE
Use StyleX dynamic styles instead of inline styles.

### DIFF
--- a/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
+++ b/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
@@ -4,9 +4,10 @@ import type { StyleXStyles } from "@stylexjs/stylex";
 import { customClassName } from "@/registry/bases/stylex/lib/utils.stylex";
 
 const styles = stylex.create({
-  root: {
+  root: (aspectRatio: number) => {
     position: "relative",
     width: "100%",
+    aspectRatio
   },
 });
 
@@ -20,9 +21,8 @@ const AspectRatio = ({
   <div
     data-slot="aspect-ratio"
     {...stylex.props(
-      styles.root,
+      styles.root(ratio),
       customClassName(className),
-      { aspectRatio: String(ratio) } as StyleXStyles,
       style as StyleXStyles
     )}
     {...props}

--- a/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
+++ b/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
@@ -4,21 +4,21 @@ import type { StyleXStyles } from "@stylexjs/stylex";
 import { customClassName } from "@/registry/bases/stylex/lib/utils.stylex";
 
 // Move this to a shared module
-type StyleXComponentProps<El extends keyof JSX.IntrinsicElements> = React.ComponentProps<El> & {
-  /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
-  className?: React.ComponentProps<El>["className"],
-  /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
-  style?: React.ComponentProps<El>["style"],
+type StyleXComponentProps<El extends keyof React.JSX.IntrinsicElements> =
+  React.ComponentProps<El> & {
+    /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
+    className?: React.ComponentProps<El>["className"];
+    /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
+    style?: React.ComponentProps<El>["style"];
 
-  sx?: StyleXStyle,
-};
-
+    sx?: StyleXStyles;
+  };
 
 const styles = stylex.create({
   root: (aspectRatio: number) => ({
+    aspectRatio,
     position: "relative",
     width: "100%",
-    aspectRatio
   }),
 });
 
@@ -26,6 +26,7 @@ const AspectRatio = ({
   ratio = 1,
   className,
   style,
+  sx,
   children,
   ...props
 }: StyleXComponentProps<"div"> & { ratio?: number }) => (
@@ -34,7 +35,8 @@ const AspectRatio = ({
     {...stylex.props(
       styles.root(ratio),
       customClassName(className),
-      style as StyleXStyles
+      style as StyleXStyles,
+      sx
     )}
     {...props}
   >

--- a/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
+++ b/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
@@ -15,11 +15,11 @@ type StyleXComponentProps<El extends keyof JSX.IntrinsicElements> = React.Compon
 
 
 const styles = stylex.create({
-  root: (aspectRatio: number) => {
+  root: (aspectRatio: number) => ({
     position: "relative",
     width: "100%",
     aspectRatio
-  },
+  }),
 });
 
 const AspectRatio = ({

--- a/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
+++ b/apps/www/registry/bases/stylex/ui/aspect-ratio.tsx
@@ -3,6 +3,17 @@ import type { StyleXStyles } from "@stylexjs/stylex";
 
 import { customClassName } from "@/registry/bases/stylex/lib/utils.stylex";
 
+// Move this to a shared module
+type StyleXComponentProps<El extends keyof JSX.IntrinsicElements> = React.ComponentProps<El> & {
+  /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
+  className?: React.ComponentProps<El>["className"],
+  /** @deprecated Prefer passing in StyleX styles with the `sx` prop */
+  style?: React.ComponentProps<El>["style"],
+
+  sx?: StyleXStyle,
+};
+
+
 const styles = stylex.create({
   root: (aspectRatio: number) => {
     position: "relative",
@@ -17,7 +28,7 @@ const AspectRatio = ({
   style,
   children,
   ...props
-}: React.ComponentProps<"div"> & { ratio?: number }) => (
+}: StyleXComponentProps<"div"> & { ratio?: number }) => (
   <div
     data-slot="aspect-ratio"
     {...stylex.props(


### PR DESCRIPTION
You should generally avoid mixing `className` and `style` with StyleX styles, letting StyleX control those two props on HTML elements completely.

You can also allow dynamic values using functions in stylex.create.

---

As a next step, you could deprecate the `className` and `style` props and accept an `sx` prop for stylex styles to be passed in.